### PR TITLE
Cleanup and make disconnecting work

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,9 +37,8 @@ dependencies {
 
     include(modImplementation('me.lucko:fabric-permissions-api:0.2-SNAPSHOT'))
 
-
-    modImplementation "io.wispforest:owo-lib:${project.owo_version}"
-    include "io.wispforest:owo-sentinel:${project.owo_version}"
+//    modImplementation "io.wispforest:owo-lib:${project.owo_version}"
+//    include "io.wispforest:owo-sentinel:${project.owo_version}"
 
     annotationProcessor compileOnly("io.wispforest:owo-lib:${project.owo_version}")
 
@@ -47,7 +46,6 @@ dependencies {
     include "io.github.ladysnake:PlayerAbilityLib:${pal_version}"
 
     modImplementation include("xyz.nucleoid:server-translations-api:${serverapi_version}")
-
 }
 
 processResources {

--- a/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/ChallengeCommand.java
+++ b/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/ChallengeCommand.java
@@ -8,18 +8,35 @@ import dev.sebastianb.nokillkillkillkill.SebaUtils;
 import dev.sebastianb.nokillkillkillkill.ability.NKKKKAbilities;
 import dev.sebastianb.nokillkillkillkill.command.ICommand;
 import net.minecraft.command.argument.EntityArgumentType;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Optional;
 import java.util.UUID;
 
 public class ChallengeCommand implements ICommand {
 
-    public static HashMap<UUID, UUID> challengePlayerMap = new HashMap<>(); // map holding which players are actively challenging each-other
+    public static ArrayList<PlayerPair> playerPairs = new ArrayList<>(); // list holding current duels
+
+    /**
+     * Will get the pair this UUID is contained in, optional will be empty if such pair doesn't exist
+     */
+    public static Optional<PlayerPair> findInPairs(UUID uuid) {
+        for (var pair : playerPairs)
+            if (pair.contains(uuid)) return Optional.of(pair);
+
+        return Optional.empty();
+    }
+
+    /**
+     * Returns true if the given UUID is in any challenge currently (in playerPairs)
+     */
+    public static boolean containsInPairs(UUID uuid) {
+        return findInPairs(uuid).isPresent();
+    }
 
     @Override
     public String commandName() {
@@ -38,60 +55,44 @@ public class ChallengeCommand implements ICommand {
             ServerPlayerEntity sourcePlayer = context.getSource().getPlayer();
             ServerPlayerEntity challengedPlayer = EntityArgumentType.getPlayer(context, "player");
 
+            assert sourcePlayer != null;
             if (sourcePlayer.equals(challengedPlayer)) {
                 // if challenger is the source player, they can't challenge themselves
                 SebaUtils.ChatUtils.saySimpleMessage(context, Text.translatable("nokillkillkillkill.command.pvp.challenge.ran_as_self"));
-            } else if (challengePlayerMap.containsKey(sourcePlayer.getUuid()) || challengePlayerMap.containsValue(sourcePlayer.getUuid())) {
-                // if the player is currently in a challenge, they can't send another challenge
-                SebaUtils.ChatUtils.saySimpleMessage(context, Text.translatable("nokillkillkillkill.command.pvp.challenge.challenger_player_is_in_challenge"));
-            } else if (challengePlayerMap.containsKey(challengedPlayer.getUuid()) || challengePlayerMap.containsValue(challengedPlayer.getUuid())) {
-                // if the challenged player is currently in a challenge, you can't send a challenge to them
-                SebaUtils.ChatUtils.saySimpleMessage(context, Text.translatable("nokillkillkillkill.command.pvp.challenge.challenged_player_is_in_challenge", challengedPlayer.getName()));
+                return Command.SINGLE_SUCCESS;
+            }
+
+            var isSourceInPair = containsInPairs(sourcePlayer.getUuid());
+            var isChallengedInPair = containsInPairs(challengedPlayer.getUuid());
+
+            if (isSourceInPair) { // source player is already in a challenge
+                SebaUtils.ChatUtils.saySimpleMessage(
+                        context,
+                        Text.translatable("nokillkillkillkill.command.pvp.challenge.challenger_player_is_in_challenge")
+                );
+            } else if (isChallengedInPair) { // challenged player is already in a challenge
+                var challengedName = challengedPlayer.getName();
+                SebaUtils.ChatUtils.saySimpleMessage(
+                        context,
+                        Text.translatable("nokillkillkillkill.command.pvp.challenge.challenged_player_is_in_challenge", challengedName)
+                );
             } else if (ChallengeInviteTimer.invitedPlayerAndSourcePlayerUUID.contains(sourcePlayer.getUuid())) {
                 // if challenger is currently challenging another player
                 SebaUtils.ChatUtils.saySimpleMessage(context, Text.translatable("nokillkillkillkill.command.pvp.challenge.command_running"));
+            } else if (ChallengeInviteTimer.invitedPlayerAndSourcePlayerUUID.containsValue(challengedPlayer.getUuid())) {
+                acceptChallenge(context, sourcePlayer, challengedPlayer);
             } else {
-                if (ChallengeInviteTimer.invitedPlayerAndSourcePlayerUUID.containsValue(challengedPlayer.getUuid())) {
-                    // removes source player from challenge if they accepted their challenge
-                    ChallengeInviteTimer.invitedPlayerAndSourcePlayerUUID.remove(sourcePlayer.getUuid());
-                    // sends message to each player letting them know request has been accepted.
-                    sourcePlayer.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.challenge.accepted_received", challengedPlayer.getName()));
-                    challengedPlayer.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.challenge.accepted_sent", sourcePlayer.getName()));
+                // send message to source player saying they've challenged the player.
+                SebaUtils.ChatUtils.saySimpleMessage(context, Text.translatable("nokillkillkillkill.command.pvp.challenge.invite_player_sent", challengedPlayer.getName()));
 
-                    // adds players to hashmap
-                    challengePlayerMap.put(challengedPlayer.getUuid(), sourcePlayer.getUuid());
-
-                    // broadcast message to each player saying a duel has started
-                    // TODO: configurable if this should announce to only the players or everyone
-                    MinecraftServer server = context.getSource().getServer();
-                    server.getPlayerManager().getPlayerList().forEach(player -> {
-                        player.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.challenge.broadcast", challengedPlayer.getName(), sourcePlayer.getName()));
-                    });
-                    // if pvp is off for the player, just send a message saying it is enabled, it's handled in the PVP mixin
-                    // TODO: clean this up and put into it's own helper method probably
-                    if (!NKKKKAbilities.Abilities.PLAYER_PVP_STATUS_ABILITY.getAbilityState(challengedPlayer)) {
-                        challengedPlayer.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.temp_enabled"));
-                    }
-                    if (!NKKKKAbilities.Abilities.PLAYER_PVP_STATUS_ABILITY.getAbilityState(sourcePlayer)) {
-                        sourcePlayer.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.temp_enabled"));
-                    }
-                    // set challenge state to true for both players
-                    NKKKKAbilities.Abilities.PLAYER_CURRENTLY_CHALLENGING_ABILITY.setAbilityState(sourcePlayer, true);
-                    NKKKKAbilities.Abilities.PLAYER_CURRENTLY_CHALLENGING_ABILITY.setAbilityState(challengedPlayer, true);
-
-                } else {
-                    // send message to source player saying they've challenged the player.
-                    SebaUtils.ChatUtils.saySimpleMessage(context, Text.translatable("nokillkillkillkill.command.pvp.challenge.invite_player_sent", challengedPlayer.getName()));
-
-                    // send message to challenged player letting them know to accept the challenge.
-                    // TODO: make command clickable and display a hover text with the command
-                    challengedPlayer.sendMessage(
-                            Text.translatable("nokillkillkillkill.command.pvp.challenge.invite_player_received", sourcePlayer.getName(),
-                                    Text.translatable("nokillkillkillkill.command.pvp.challenge.invite_player_received.click_here")
-                            )
-                    );
-                    ChallengeInviteTimer.runChallengeSchedule(challengedPlayer, sourcePlayer, 30);
-                }
+                // send message to challenged player letting them know to accept the challenge.
+                // TODO: make command clickable and display a hover text with the command
+                challengedPlayer.sendMessage(
+                        Text.translatable("nokillkillkillkill.command.pvp.challenge.invite_player_received", sourcePlayer.getName(),
+                                Text.translatable("nokillkillkillkill.command.pvp.challenge.invite_player_received.click_here")
+                        )
+                );
+                ChallengeInviteTimer.runChallengeSchedule(challengedPlayer, sourcePlayer, 30);
             }
 
         } catch (CommandSyntaxException e) {
@@ -100,5 +101,43 @@ public class ChallengeCommand implements ICommand {
         return Command.SINGLE_SUCCESS;
     }
 
+    private static void acceptChallenge(
+            CommandContext<ServerCommandSource> context,
+            ServerPlayerEntity sourcePlayer,
+            ServerPlayerEntity challengedPlayer
+    ) {
+        var sourceName = sourcePlayer.getName();
+        var challengedName = sourcePlayer.getName();
 
+        // removes source player from challenge if they accepted their challenge
+        ChallengeInviteTimer.invitedPlayerAndSourcePlayerUUID.remove(sourcePlayer.getUuid());
+        // sends message to each player letting them know request has been accepted.
+        sourcePlayer.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.challenge.accepted_received", challengedName));
+        challengedPlayer.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.challenge.accepted_sent", sourceName));
+
+        // add new challenge pair
+        playerPairs.add(new PlayerPair(challengedPlayer.getUuid(), sourcePlayer.getUuid()));
+
+        // broadcast message to each player saying a duel has started
+        // TODO: configurable if this should announce to only the players or everyone
+        var server = context.getSource().getServer();
+        server.getPlayerManager()
+                .getPlayerList()
+                .forEach(player ->player.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.challenge.broadcast", challengedName, sourceName)));
+
+        announceChallengeBegin(sourcePlayer, challengedPlayer);
+    }
+
+    private static void announceChallengeBegin(ServerPlayerEntity sourcePlayer, ServerPlayerEntity challengedPlayer) {
+        // if pvp is off for the player, just send a message saying it is enabled, it's handled in the PVP mixin
+        if (!NKKKKAbilities.Abilities.PLAYER_PVP_STATUS_ABILITY.getAbilityState(challengedPlayer)) {
+            challengedPlayer.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.temp_enabled"));
+        }
+        if (!NKKKKAbilities.Abilities.PLAYER_PVP_STATUS_ABILITY.getAbilityState(sourcePlayer)) {
+            sourcePlayer.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.temp_enabled"));
+        }
+        // set challenge state to true for both players
+        NKKKKAbilities.Abilities.PLAYER_CURRENTLY_CHALLENGING_ABILITY.setAbilityState(sourcePlayer, true);
+        NKKKKAbilities.Abilities.PLAYER_CURRENTLY_CHALLENGING_ABILITY.setAbilityState(challengedPlayer, true);
+    }
 }

--- a/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/ChallengeCommand.java
+++ b/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/ChallengeCommand.java
@@ -35,7 +35,7 @@ public class ChallengeCommand implements ICommand {
             ServerPlayerEntity challengedPlayer = EntityArgumentType.getPlayer(context, "player");
 
             if (sourcePlayer == null) { // sent by server (I think?)
-                context.getSource().sendMessage(Text.literal("Please execute this command as a player"));
+                context.getSource().sendMessage(Text.translatable("nokillkillkillkill.command.pvp.no_source_player"));
             } else if (sourcePlayer.equals(challengedPlayer)) { // prevent player challenging themselves
                 SebaUtils.ChatUtils.saySimpleMessage(context, Text.translatable("nokillkillkillkill.command.pvp.challenge.ran_as_self"));
             } else if (challenges.contains(sourcePlayer)) { // source player is already in a duel

--- a/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/ChallengeCommand.java
+++ b/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/ChallengeCommand.java
@@ -88,7 +88,7 @@ public class ChallengeCommand implements ICommand {
                         Text.translatable("nokillkillkillkill.command.pvp.challenge.invite_player_received.click_here")
                 )
         );
-        ChallengeInviteTimer.createInvite(sourcePlayer, challengedPlayer, 30);
+        ChallengeInviteTimer.createInvite(sourcePlayer, challengedPlayer);
     }
 
     private static void acceptChallenge(CommandContext<ServerCommandSource> context, PlayerPair pair) {

--- a/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/ChallengeCommand.java
+++ b/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/ChallengeCommand.java
@@ -15,7 +15,6 @@ import net.minecraft.text.Text;
 
 import java.util.ArrayList;
 import java.util.Optional;
-import java.util.UUID;
 
 public class ChallengeCommand implements ICommand {
 
@@ -24,9 +23,9 @@ public class ChallengeCommand implements ICommand {
     /**
      * Will get the pair this UUID is contained in, optional will be empty if such pair doesn't exist
      */
-    public static Optional<PlayerPair> findInPairs(UUID uuid) {
+    public static Optional<PlayerPair> findInPairs(ServerPlayerEntity player) {
         for (var pair : playerPairs)
-            if (pair.contains(uuid)) return Optional.of(pair);
+            if (pair.contains(player)) return Optional.of(pair);
 
         return Optional.empty();
     }
@@ -34,8 +33,8 @@ public class ChallengeCommand implements ICommand {
     /**
      * Returns true if the given UUID is in any challenge currently (in playerPairs)
      */
-    public static boolean containsInPairs(UUID uuid) {
-        return findInPairs(uuid).isPresent();
+    public static boolean containsInPairs(ServerPlayerEntity player) {
+        return findInPairs(player).isPresent();
     }
 
     @Override
@@ -62,8 +61,8 @@ public class ChallengeCommand implements ICommand {
                 return Command.SINGLE_SUCCESS;
             }
 
-            var isSourceInPair = containsInPairs(sourcePlayer.getUuid());
-            var isChallengedInPair = containsInPairs(challengedPlayer.getUuid());
+            var isSourceInPair = containsInPairs(sourcePlayer);
+            var isChallengedInPair = containsInPairs(challengedPlayer);
 
             if (isSourceInPair) { // source player is already in a challenge
                 SebaUtils.ChatUtils.saySimpleMessage(
@@ -116,7 +115,7 @@ public class ChallengeCommand implements ICommand {
         challengedPlayer.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.challenge.accepted_sent", sourceName));
 
         // add new challenge pair
-        playerPairs.add(new PlayerPair(challengedPlayer.getUuid(), sourcePlayer.getUuid()));
+        playerPairs.add(new PlayerPair(challengedPlayer, sourcePlayer));
 
         // broadcast message to each player saying a duel has started
         // TODO: configurable if this should announce to only the players or everyone

--- a/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/ChallengeCommand.java
+++ b/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/ChallengeCommand.java
@@ -7,35 +7,15 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.sebastianb.nokillkillkillkill.SebaUtils;
 import dev.sebastianb.nokillkillkillkill.ability.NKKKKAbilities;
 import dev.sebastianb.nokillkillkillkill.command.ICommand;
+import dev.sebastianb.nokillkillkillkill.command.challenge.pairstructs.PlayerPairList;
 import net.minecraft.command.argument.EntityArgumentType;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 
-import java.util.ArrayList;
-import java.util.Optional;
-
 public class ChallengeCommand implements ICommand {
-
-    public static ArrayList<PlayerPair> playerPairs = new ArrayList<>(); // list holding current duels
-
-    /**
-     * Will get the pair this UUID is contained in, optional will be empty if such pair doesn't exist
-     */
-    public static Optional<PlayerPair> findInPairs(ServerPlayerEntity player) {
-        for (var pair : playerPairs)
-            if (pair.contains(player)) return Optional.of(pair);
-
-        return Optional.empty();
-    }
-
-    /**
-     * Returns true if the given UUID is in any challenge currently (in playerPairs)
-     */
-    public static boolean containsInPairs(ServerPlayerEntity player) {
-        return findInPairs(player).isPresent();
-    }
+    public static PlayerPairList challenges = new PlayerPairList(); // list holding current duels
 
     @Override
     public String commandName() {
@@ -54,89 +34,93 @@ public class ChallengeCommand implements ICommand {
             ServerPlayerEntity sourcePlayer = context.getSource().getPlayer();
             ServerPlayerEntity challengedPlayer = EntityArgumentType.getPlayer(context, "player");
 
-            assert sourcePlayer != null;
-            if (sourcePlayer.equals(challengedPlayer)) {
-                // if challenger is the source player, they can't challenge themselves
+            if (sourcePlayer == null) { // sent by server (I think?)
+                context.getSource().sendMessage(Text.literal("Please execute this command as a player"));
+            } else if (sourcePlayer.equals(challengedPlayer)) { // prevent player challenging themselves
                 SebaUtils.ChatUtils.saySimpleMessage(context, Text.translatable("nokillkillkillkill.command.pvp.challenge.ran_as_self"));
-                return Command.SINGLE_SUCCESS;
-            }
-
-            var isSourceInPair = containsInPairs(sourcePlayer);
-            var isChallengedInPair = containsInPairs(challengedPlayer);
-
-            if (isSourceInPair) { // source player is already in a challenge
+            } else if (challenges.contains(sourcePlayer)) { // source player is already in a duel
                 SebaUtils.ChatUtils.saySimpleMessage(
                         context,
                         Text.translatable("nokillkillkillkill.command.pvp.challenge.challenger_player_is_in_challenge")
                 );
-            } else if (isChallengedInPair) { // challenged player is already in a challenge
+            } else if (challenges.contains(challengedPlayer)) { // challenged player is already in a duel
                 var challengedName = challengedPlayer.getName();
                 SebaUtils.ChatUtils.saySimpleMessage(
                         context,
                         Text.translatable("nokillkillkillkill.command.pvp.challenge.challenged_player_is_in_challenge", challengedName)
                 );
-            } else if (ChallengeInviteTimer.invitedPlayerAndSourcePlayerUUID.contains(sourcePlayer.getUuid())) {
-                // if challenger is currently challenging another player
-                SebaUtils.ChatUtils.saySimpleMessage(context, Text.translatable("nokillkillkillkill.command.pvp.challenge.command_running"));
-            } else if (ChallengeInviteTimer.invitedPlayerAndSourcePlayerUUID.containsValue(challengedPlayer.getUuid())) {
-                acceptChallenge(context, sourcePlayer, challengedPlayer);
             } else {
-                // send message to source player saying they've challenged the player.
-                SebaUtils.ChatUtils.saySimpleMessage(context, Text.translatable("nokillkillkillkill.command.pvp.challenge.invite_player_sent", challengedPlayer.getName()));
-
-                // send message to challenged player letting them know to accept the challenge.
-                // TODO: make command clickable and display a hover text with the command
-                challengedPlayer.sendMessage(
-                        Text.translatable("nokillkillkillkill.command.pvp.challenge.invite_player_received", sourcePlayer.getName(),
-                                Text.translatable("nokillkillkillkill.command.pvp.challenge.invite_player_received.click_here")
-                        )
-                );
-                ChallengeInviteTimer.runChallengeSchedule(challengedPlayer, sourcePlayer, 30);
+                attemptToChallenge(context, sourcePlayer, challengedPlayer);
             }
-
         } catch (CommandSyntaxException e) {
             throw new RuntimeException(e);
         }
+
         return Command.SINGLE_SUCCESS;
     }
 
-    private static void acceptChallenge(
+    private static void attemptToChallenge(
             CommandContext<ServerCommandSource> context,
             ServerPlayerEntity sourcePlayer,
             ServerPlayerEntity challengedPlayer
     ) {
-        var sourceName = sourcePlayer.getName();
-        var challengedName = sourcePlayer.getName();
+        var maybePair = ChallengeInviteTimer.playerInvites.find(challengedPlayer);
 
-        // removes source player from challenge if they accepted their challenge
-        ChallengeInviteTimer.invitedPlayerAndSourcePlayerUUID.remove(sourcePlayer.getUuid());
+        if (maybePair.isPresent()) {
+            var pair = maybePair.get();
+
+            if (pair.contains(sourcePlayer)) {
+                acceptChallenge(context, pair);
+            } else {
+                // either player has already challenged someone else
+                SebaUtils.ChatUtils.saySimpleMessage(context, Text.translatable("nokillkillkillkill.command.pvp.challenge.command_running"));
+            }
+            return;
+        }
+
+        // send message to source player saying they've challenged the player.
+        SebaUtils.ChatUtils.saySimpleMessage(context, Text.translatable("nokillkillkillkill.command.pvp.challenge.invite_player_sent", challengedPlayer.getName()));
+
+        // send message to challenged player letting them know to accept the challenge.
+        // TODO: make command clickable and display a hover text with the command
+        challengedPlayer.sendMessage(
+                Text.translatable("nokillkillkillkill.command.pvp.challenge.invite_player_received", sourcePlayer.getName(),
+                        Text.translatable("nokillkillkillkill.command.pvp.challenge.invite_player_received.click_here")
+                )
+        );
+        ChallengeInviteTimer.createInvite(sourcePlayer, challengedPlayer, 30);
+    }
+
+    private static void acceptChallenge(CommandContext<ServerCommandSource> context, PlayerPair pair) {
+        var challengerName = pair.challenger().getName();
+        var opponentName = pair.opponent().getName();
+
+        ChallengeInviteTimer.playerInvites.remove(pair);
         // sends message to each player letting them know request has been accepted.
-        sourcePlayer.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.challenge.accepted_received", challengedName));
-        challengedPlayer.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.challenge.accepted_sent", sourceName));
+        pair.challenger().sendMessage(Text.translatable("nokillkillkillkill.command.pvp.challenge.accepted_sent", opponentName));
+        pair.opponent().sendMessage(Text.translatable("nokillkillkillkill.command.pvp.challenge.accepted_received", challengerName));
 
-        // add new challenge pair
-        playerPairs.add(new PlayerPair(challengedPlayer, sourcePlayer));
-
+        challenges.add(pair);
         // broadcast message to each player saying a duel has started
         // TODO: configurable if this should announce to only the players or everyone
         var server = context.getSource().getServer();
         server.getPlayerManager()
                 .getPlayerList()
-                .forEach(player ->player.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.challenge.broadcast", challengedName, sourceName)));
+                .forEach(player -> player.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.challenge.broadcast", challengerName, opponentName)));
 
-        announceChallengeBegin(sourcePlayer, challengedPlayer);
+        setPVPStates(pair);
     }
 
-    private static void announceChallengeBegin(ServerPlayerEntity sourcePlayer, ServerPlayerEntity challengedPlayer) {
+    private static void setPVPStates(PlayerPair pair) {
         // if pvp is off for the player, just send a message saying it is enabled, it's handled in the PVP mixin
-        if (!NKKKKAbilities.Abilities.PLAYER_PVP_STATUS_ABILITY.getAbilityState(challengedPlayer)) {
-            challengedPlayer.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.temp_enabled"));
+        if (!NKKKKAbilities.Abilities.PLAYER_PVP_STATUS_ABILITY.getAbilityState(pair.opponent())) {
+            pair.opponent().sendMessage(Text.translatable("nokillkillkillkill.command.pvp.temp_enabled"));
         }
-        if (!NKKKKAbilities.Abilities.PLAYER_PVP_STATUS_ABILITY.getAbilityState(sourcePlayer)) {
-            sourcePlayer.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.temp_enabled"));
+        if (!NKKKKAbilities.Abilities.PLAYER_PVP_STATUS_ABILITY.getAbilityState(pair.challenger())) {
+            pair.challenger().sendMessage(Text.translatable("nokillkillkillkill.command.pvp.temp_enabled"));
         }
         // set challenge state to true for both players
-        NKKKKAbilities.Abilities.PLAYER_CURRENTLY_CHALLENGING_ABILITY.setAbilityState(sourcePlayer, true);
-        NKKKKAbilities.Abilities.PLAYER_CURRENTLY_CHALLENGING_ABILITY.setAbilityState(challengedPlayer, true);
+        NKKKKAbilities.Abilities.PLAYER_CURRENTLY_CHALLENGING_ABILITY.setAbilityState(pair.challenger(), true);
+        NKKKKAbilities.Abilities.PLAYER_CURRENTLY_CHALLENGING_ABILITY.setAbilityState(pair.opponent(), true);
     }
 }

--- a/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/ChallengeInviteTimer.java
+++ b/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/ChallengeInviteTimer.java
@@ -21,8 +21,8 @@ public final class ChallengeInviteTimer {
         }, 0, 1000); // 1,000 ms
     }
 
-    public static void createInvite(ServerPlayerEntity from, ServerPlayerEntity to, int seconds) {
-        playerInvites.add(InvitePair.of(from, to, seconds));
+    public static void createInvite(ServerPlayerEntity from, ServerPlayerEntity to) {
+        playerInvites.add(new InvitePair(new PlayerPair(from, to)));
     }
 
     private static void progressInviteTimers() {

--- a/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/ChallengeInviteTimer.java
+++ b/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/ChallengeInviteTimer.java
@@ -1,57 +1,50 @@
 package dev.sebastianb.nokillkillkillkill.command.challenge;
 
+import dev.sebastianb.nokillkillkillkill.command.challenge.pairstructs.InvitePair;
+import dev.sebastianb.nokillkillkillkill.command.challenge.pairstructs.PlayerInviteList;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 
-import java.util.UUID;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Timer;
+import java.util.TimerTask;
 
-// A thread to check if a player is currently waiting on a challenge invite
-public class ChallengeInviteTimer implements Runnable {
+public final class ChallengeInviteTimer {
+    private static final Timer timer = new Timer();
+    public static final PlayerInviteList playerInvites = new PlayerInviteList();
 
-    // FIXME: don't make this concurrent or update to a record
-    public static volatile ConcurrentHashMap<UUID, UUID> invitedPlayerAndSourcePlayerUUID = new ConcurrentHashMap<>(); // holds player UUID and challenger UUID
-
-    private static final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
-
-    public static void runChallengeSchedule(ServerPlayerEntity invitedPlayer, ServerPlayerEntity challengerPlayer, int maxSecondsAlive) {
-        executor.scheduleAtFixedRate(new ChallengeInviteTimer(invitedPlayer, challengerPlayer, maxSecondsAlive, executor), 0, 1, TimeUnit.SECONDS);
+    static {
+        timer.scheduleAtFixedRate(new TimerTask() {
+            @Override
+            public void run() {
+                progressInviteTimers();
+            }
+        }, 0, 1000); // 1,000 ms
     }
 
-    private final AtomicInteger secondsAlive;
-    private final ServerPlayerEntity invitedPlayer;
-
-    private final ServerPlayerEntity challengerPlayer;
-    private final UUID invitedPlayerUUID;
-    private final UUID challengerPlayerUUID;
-
-    public ChallengeInviteTimer(ServerPlayerEntity invitedPlayer, ServerPlayerEntity challengerPlayer, int maxSecondsAlive, ScheduledExecutorService executor) {
-        this.invitedPlayer = invitedPlayer;
-        this.challengerPlayer = challengerPlayer;
-        invitedPlayerUUID = invitedPlayer.getUuid();
-        this.challengerPlayerUUID = challengerPlayer.getUuid();
-        this.secondsAlive = new AtomicInteger(maxSecondsAlive);
-        invitedPlayerAndSourcePlayerUUID.putIfAbsent(this.invitedPlayerUUID, this.challengerPlayerUUID);
+    public static void createInvite(ServerPlayerEntity from, ServerPlayerEntity to, int seconds) {
+        playerInvites.add(InvitePair.of(from, to, seconds));
     }
 
-    @Override
-    public synchronized void run() {
-        if (!invitedPlayerAndSourcePlayerUUID.containsKey(invitedPlayer.getUuid())) {
-            executor.shutdown();
-            return;
+    private static void progressInviteTimers() {
+        for (var invite : playerInvites) {
+            invite.secondsLeft -= 1;
+
+            invite.pair.opponent().sendMessage(Text.literal(String.valueOf(invite.secondsLeft)), false);
+
+            if (invite.secondsLeft <= 0) {
+                playerInvites.remove(invite);
+
+                invite.pair.challenger().sendMessage(Text.translatable(
+                        "nokillkillkillkill.command.pvp.challenge.invite_expired_sent",
+                        invite.pair.opponent().getName()
+                ), false);
+                invite.pair.opponent().sendMessage(Text.translatable(
+                        "nokillkillkillkill.command.pvp.challenge.invite_expired_received",
+                        invite.pair.challenger().getName()
+                ), false);
+            }
         }
-
-        // TODO: make this display 15, 10, 5, 3, 2, 1 then expire. Also make it pretty + use a translatable
-        invitedPlayer.sendMessage(Text.literal(secondsAlive.toString()), false);
-
-        if (secondsAlive.decrementAndGet() < 0) {
-            invitedPlayer.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.challenge.invite_expired_received", challengerPlayer.getName()), false);
-            challengerPlayer.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.challenge.invite_expired_sent", invitedPlayer.getName()), false);
-            invitedPlayerAndSourcePlayerUUID.remove(invitedPlayerUUID);
-            executor.shutdown();
-        }
-
     }
 
+    private ChallengeInviteTimer() {}
 }

--- a/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/PlayerPair.java
+++ b/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/PlayerPair.java
@@ -1,0 +1,9 @@
+package dev.sebastianb.nokillkillkillkill.command.challenge;
+
+import java.util.UUID;
+
+public record PlayerPair(UUID challenger, UUID opponent) {
+    public boolean contains(UUID uuid) {
+        return (uuid.equals(challenger) || uuid.equals(opponent));
+    }
+}

--- a/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/PlayerPair.java
+++ b/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/PlayerPair.java
@@ -1,9 +1,9 @@
 package dev.sebastianb.nokillkillkillkill.command.challenge;
 
-import java.util.UUID;
+import net.minecraft.server.network.ServerPlayerEntity;
 
-public record PlayerPair(UUID challenger, UUID opponent) {
-    public boolean contains(UUID uuid) {
-        return (uuid.equals(challenger) || uuid.equals(opponent));
+public record PlayerPair(ServerPlayerEntity challenger, ServerPlayerEntity opponent) {
+    public boolean contains(ServerPlayerEntity player) {
+        return (player == challenger || player == opponent);
     }
 }

--- a/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/PlayerPair.java
+++ b/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/PlayerPair.java
@@ -6,4 +6,10 @@ public record PlayerPair(ServerPlayerEntity challenger, ServerPlayerEntity oppon
     public boolean contains(ServerPlayerEntity player) {
         return (player == challenger || player == opponent);
     }
+
+    // For all intents and purposes, a pair should be equal if it contains both of the same players
+    @Override
+    public int hashCode() {
+        return challenger.hashCode() + opponent.hashCode();
+    }
 }

--- a/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/pairstructs/InvitePair.java
+++ b/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/pairstructs/InvitePair.java
@@ -1,0 +1,19 @@
+package dev.sebastianb.nokillkillkillkill.command.challenge.pairstructs;
+
+import dev.sebastianb.nokillkillkillkill.command.challenge.PlayerPair;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+public class InvitePair {
+    public final PlayerPair pair;
+    public int secondsLeft;
+
+    public InvitePair(PlayerPair pair, int seconds) {
+        this.pair = pair;
+        this.secondsLeft = seconds;
+    }
+
+    public static InvitePair of(ServerPlayerEntity challenger, ServerPlayerEntity opponent, int seconds) {
+        return new InvitePair(new PlayerPair(challenger, opponent), seconds);
+    }
+}
+

--- a/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/pairstructs/InvitePair.java
+++ b/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/pairstructs/InvitePair.java
@@ -1,19 +1,13 @@
 package dev.sebastianb.nokillkillkillkill.command.challenge.pairstructs;
 
 import dev.sebastianb.nokillkillkillkill.command.challenge.PlayerPair;
-import net.minecraft.server.network.ServerPlayerEntity;
 
 public class InvitePair {
     public final PlayerPair pair;
-    public int secondsLeft;
+    public int secondsLeft = 30;
 
-    public InvitePair(PlayerPair pair, int seconds) {
+    public InvitePair(PlayerPair pair) {
         this.pair = pair;
-        this.secondsLeft = seconds;
-    }
-
-    public static InvitePair of(ServerPlayerEntity challenger, ServerPlayerEntity opponent, int seconds) {
-        return new InvitePair(new PlayerPair(challenger, opponent), seconds);
     }
 }
 

--- a/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/pairstructs/PlayerInviteList.java
+++ b/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/pairstructs/PlayerInviteList.java
@@ -6,13 +6,7 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import java.util.ArrayList;
 import java.util.Optional;
 
-// measure performance
 public class PlayerInviteList extends ArrayList<InvitePair> {
-    @Override
-    public boolean add(InvitePair invite) {
-        return !this.contains(invite) && this.add(invite);
-    }
-
     public void remove(PlayerPair pair) throws IndexOutOfBoundsException {
         for (int i = 0; i < this.size(); i++) {
             if (this.get(i).pair.equals(pair)) {

--- a/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/pairstructs/PlayerInviteList.java
+++ b/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/pairstructs/PlayerInviteList.java
@@ -1,0 +1,32 @@
+package dev.sebastianb.nokillkillkillkill.command.challenge.pairstructs;
+
+import dev.sebastianb.nokillkillkillkill.command.challenge.PlayerPair;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+// measure performance
+public class PlayerInviteList extends ArrayList<InvitePair> {
+    @Override
+    public boolean add(InvitePair invite) {
+        return !this.contains(invite) && this.add(invite);
+    }
+
+    public void remove(PlayerPair pair) throws IndexOutOfBoundsException {
+        for (int i = 0; i < this.size(); i++) {
+            if (this.get(i).pair.equals(pair)) {
+                this.remove(i);
+                return;
+            }
+        }
+    }
+
+    public Optional<PlayerPair> find(ServerPlayerEntity player) {
+        for (var invite : this) {
+            if (invite.pair.contains(player)) return Optional.of(invite.pair);
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/pairstructs/PlayerPairList.java
+++ b/src/main/java/dev/sebastianb/nokillkillkillkill/command/challenge/pairstructs/PlayerPairList.java
@@ -1,0 +1,26 @@
+package dev.sebastianb.nokillkillkillkill.command.challenge.pairstructs;
+
+import dev.sebastianb.nokillkillkillkill.command.challenge.PlayerPair;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+public class PlayerPairList extends ArrayList<PlayerPair> {
+    /**
+     * Will get the pair this UUID is contained in, optional will be empty if such pair doesn't exist
+     */
+    public Optional<PlayerPair> find(ServerPlayerEntity player) {
+        for (var pair : this)
+            if (pair.contains(player)) return Optional.of(pair);
+
+        return Optional.empty();
+    }
+
+    /**
+     * Returns true if the given UUID is in any challenge currently (in playerPairs)
+     */
+    public boolean contains(ServerPlayerEntity player) {
+        return find(player).isPresent();
+    }
+}

--- a/src/main/java/dev/sebastianb/nokillkillkillkill/mixin/PlayerManagerMixin.java
+++ b/src/main/java/dev/sebastianb/nokillkillkillkill/mixin/PlayerManagerMixin.java
@@ -2,11 +2,13 @@ package dev.sebastianb.nokillkillkillkill.mixin;
 
 
 import dev.sebastianb.nokillkillkillkill.ability.NKKKKAbilities;
+import dev.sebastianb.nokillkillkillkill.command.challenge.ChallengeCommand;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.PlayerManager;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.stat.Stats;
+import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -35,7 +37,6 @@ public abstract class PlayerManagerMixin {
         // this should call if they left while currently in a match
         if (NKKKKAbilities.Abilities.PLAYER_CURRENTLY_CHALLENGING_ABILITY.getAbilityState(player)) {
             // TODO: let player know they left while in a match
-
         }
         // everytime a player connects, they should be set to not in a challenge state if they disconnect while in challenge mode
         NKKKKAbilities.Abilities.PLAYER_CURRENTLY_CHALLENGING_ABILITY.setAbilityState(player, false);
@@ -44,10 +45,19 @@ public abstract class PlayerManagerMixin {
     // I think this is the disconnect method, seems to call when a player disconnects
     @Inject(at = @At(value = "TAIL"), method = "remove")
     private void onPlayerDisconnect(ServerPlayerEntity player, CallbackInfo ci) {
-        // TODO: have a condition to check if the player is even in the hashmap
-        // TODO: end the challenge state of the player that didn't leave and get rid of both from the challenge hashmap
-        // TODO: broadcast message with the player that left and who won by default
+        var maybePair = ChallengeCommand.challenges.find(player);
+        if (maybePair.isEmpty()) return; // no challenge contains this player
 
+        var pair = maybePair.get();
+        var other = player == pair.challenger() ? pair.opponent() : pair.challenger(); // other player
+
+        // end the challenge state of the player that didn't leave, and remove pair from challenges
+        NKKKKAbilities.Abilities.PLAYER_CURRENTLY_CHALLENGING_ABILITY.setAbilityState(other, false);
+        ChallengeCommand.challenges.remove(pair);
+
+        // broadcast message with the player that left and who won by default
+        var msg = String.format("You win by default! " + player.getName() + " has left.");
+        other.sendMessage(Text.literal(msg));
     }
 
 }

--- a/src/main/java/dev/sebastianb/nokillkillkillkill/mixin/PlayerManagerMixin.java
+++ b/src/main/java/dev/sebastianb/nokillkillkillkill/mixin/PlayerManagerMixin.java
@@ -36,8 +36,9 @@ public abstract class PlayerManagerMixin {
 
         // this should call if they left while currently in a match
         if (NKKKKAbilities.Abilities.PLAYER_CURRENTLY_CHALLENGING_ABILITY.getAbilityState(player)) {
-            // TODO: let player know they left while in a match
+            player.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.left_mid_match"));
         }
+
         // everytime a player connects, they should be set to not in a challenge state if they disconnect while in challenge mode
         NKKKKAbilities.Abilities.PLAYER_CURRENTLY_CHALLENGING_ABILITY.setAbilityState(player, false);
     }

--- a/src/main/java/dev/sebastianb/nokillkillkillkill/mixin/PlayerManagerMixin.java
+++ b/src/main/java/dev/sebastianb/nokillkillkillkill/mixin/PlayerManagerMixin.java
@@ -36,7 +36,7 @@ public abstract class PlayerManagerMixin {
 
         // this should call if they left while currently in a match
         if (NKKKKAbilities.Abilities.PLAYER_CURRENTLY_CHALLENGING_ABILITY.getAbilityState(player)) {
-            player.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.left_mid_match"));
+            player.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.challenge.you_disconnected"));
         }
 
         // everytime a player connects, they should be set to not in a challenge state if they disconnect while in challenge mode
@@ -57,8 +57,7 @@ public abstract class PlayerManagerMixin {
         ChallengeCommand.challenges.remove(pair);
 
         // broadcast message with the player that left and who won by default
-        var msg = String.format("You win by default! " + player.getName() + " has left.");
-        other.sendMessage(Text.literal(msg));
+        other.sendMessage(Text.translatable("nokillkillkillkill.command.pvp.challenge.other_disconnected", player.getName()));
     }
 
 }

--- a/src/main/resources/data/nokillkillkillkill/lang/en_us.json
+++ b/src/main/resources/data/nokillkillkillkill/lang/en_us.json
@@ -20,5 +20,6 @@
   "nokillkillkillkill.command.pvp.challenge.not_near_player": "§l§4Get within %s blocks of the target player to run this command.",
   "nokillkillkillkill.command.pvp.challenge.target_player_pvp_enabled": "§l§4PvP has been enabled for %s.",
   "nokillkillkillkill.command.pvp.challenge.broadcast": "§l§4%s has challenged %s to a fight!",
-  "nokillkillkillkill.command.pvp.temp_enabled": "§l§4PvP has been temporally enabled."
+  "nokillkillkillkill.command.pvp.temp_enabled": "§l§4PvP has been temporally enabled.",
+  "nokillkillkillkill.command.pvp.left_mid_match": "§l§4You left during a match! Your opponent won by default."
 }

--- a/src/main/resources/data/nokillkillkillkill/lang/en_us.json
+++ b/src/main/resources/data/nokillkillkillkill/lang/en_us.json
@@ -20,6 +20,8 @@
   "nokillkillkillkill.command.pvp.challenge.not_near_player": "§l§4Get within %s blocks of the target player to run this command.",
   "nokillkillkillkill.command.pvp.challenge.target_player_pvp_enabled": "§l§4PvP has been enabled for %s.",
   "nokillkillkillkill.command.pvp.challenge.broadcast": "§l§4%s has challenged %s to a fight!",
+  "nokillkillkillkill.command.pvp.challenge.other_disconnected": "§l§4You win by default! %s has left.",
+  "nokillkillkillkill.command.pvp.challenge.you_disconnected": "§l§4You left during a match! Your opponent won by default.",
   "nokillkillkillkill.command.pvp.temp_enabled": "§l§4PvP has been temporally enabled.",
-  "nokillkillkillkill.command.pvp.left_mid_match": "§l§4You left during a match! Your opponent won by default."
+  "nokillkillkillkill.command.pvp.no_source_player": "§l§4Please execute this command as a player!"
 }


### PR DESCRIPTION
_This pull request switches from maps to custom array lists containing PlayerPair records, and also knocks out many TODOs_

By using a custom PlayerPair record we can ensure the entities referenced don't change, we have obvious order and a hard link between the pair (aka the `challenger()` or `opponent()` fields).

This extends to the custom PlayerPair list and invites list which lets us have nice methods. For example, `find` searches if a player exists in any pair in the list and gives us the full pair if found.

I chose ArrayList as our data structure as we iterate a lot (every second to count down all invites and when searching for individual players) while only removing/adding a few times.