### PR TITLE
track challenge attempts and wins persistently + fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-# NoKillKillKillKill
+# NoKill
 
 This is a work-in-progress mod (feature imcomplete as of now) for Minecraft Fabric that adds the ability to enable or disable PvP, as well as allowing players to duel each other.
-
 
 # Usage
 To enable or disable PvP combat, use the command /pvp enable or /pvp disable.

--- a/src/main/java/dev/sebastianb/nokill/NoKill.java
+++ b/src/main/java/dev/sebastianb/nokill/NoKill.java
@@ -7,7 +7,7 @@ import net.fabricmc.api.ModInitializer;
 import java.util.logging.Logger;
 
 public class NoKill implements ModInitializer {
-
+    public static final String MOD_ID = "nokill";
     public static final Logger LOGGER = Logger.getLogger("nokill");
 
     @Override

--- a/src/main/java/dev/sebastianb/nokill/command/NoKillCommand.java
+++ b/src/main/java/dev/sebastianb/nokill/command/NoKillCommand.java
@@ -6,8 +6,6 @@ import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 
-import java.util.ArrayList;
-
 public class NoKillCommand {
 
     private static final ICommand[] commands = {

--- a/src/main/java/dev/sebastianb/nokill/command/NoKillCommand.java
+++ b/src/main/java/dev/sebastianb/nokill/command/NoKillCommand.java
@@ -10,19 +10,17 @@ import java.util.ArrayList;
 
 public class NoKillCommand {
 
-    private static final ArrayList<ICommand> commands = new ArrayList<>();
+    private static final ICommand[] commands = {
+            new ChallengeCommand(),
+            new PVPStatusCommand(),
+            // new PVPStatusCommand.PVPOnCommand()
+            // new PVPStatusCommand.PVPOffCommand()
+    };
 
     private static final String[] commandLiterals = new String[]{"pvp", "p"};
 
 
     public static void register() {
-
-        commands.add(new ChallengeCommand());
-
-        commands.add(new PVPStatusCommand());
-        commands.add(new PVPStatusCommand.PVPOnCommand());
-        commands.add(new PVPStatusCommand.PVPOffCommand());
-
         CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
             for (ICommand command : commands) {
                 for (String literal : commandLiterals) {
@@ -34,10 +32,9 @@ public class NoKillCommand {
                 }
             }
         });
-
     }
 
-    protected static ArrayList<ICommand> getCommands() {
+    protected static ICommand[] getCommands() {
         return commands;
     }
 

--- a/src/main/java/dev/sebastianb/nokill/command/PVPStatusCommand.java
+++ b/src/main/java/dev/sebastianb/nokill/command/PVPStatusCommand.java
@@ -36,62 +36,62 @@ public class PVPStatusCommand implements ICommand {
         return Command.SINGLE_SUCCESS;
     }
 
-    static class PVPOnCommand implements ICommand {
-
-        @Override
-        public String commandName() {
-            return "on";
-        }
-
-        @Override
-        public LiteralArgumentBuilder<ServerCommandSource> registerNode() {
-            return CommandManager.literal(commandName())
-                    .executes(this::execute);
-        }
-
-        private int execute(CommandContext<ServerCommandSource> context) {
-            ServerPlayerEntity player = context.getSource().getPlayer();
-            boolean playerPVPStatus = NoKillAbilities.Abilities.PLAYER_PVP_STATUS_ABILITY.getAbilityState(player);
-
-            if (!playerPVPStatus) {
-                SebaUtils.ChatUtils.saySimpleMessage(context, Text.translatable("nokill.command.pvp.enabled"));
-            } else {
-                SebaUtils.ChatUtils.saySimpleMessage(context, Text.translatable("nokill.command.pvp.already_enabled"));
-            }
-
-            NoKillAbilities.Abilities.PLAYER_PVP_STATUS_ABILITY.setAbilityState(player, true);
-            return Command.SINGLE_SUCCESS;
-        }
-
-    }
-
-    static class PVPOffCommand implements ICommand {
-
-        @Override
-        public String commandName() {
-            return "off";
-        }
-
-        @Override
-        public LiteralArgumentBuilder<ServerCommandSource> registerNode() {
-            return CommandManager.literal(commandName())
-                    .executes(this::execute);
-        }
-
-        private int execute(CommandContext<ServerCommandSource> context) {
-            ServerPlayerEntity player = context.getSource().getPlayer();
-            boolean playerPVPStatus = NoKillAbilities.Abilities.PLAYER_PVP_STATUS_ABILITY.getAbilityState(player);
-
-            if (playerPVPStatus) {
-                SebaUtils.ChatUtils.saySimpleMessage(context, Text.translatable("nokill.command.pvp.disabled"));
-            } else {
-                SebaUtils.ChatUtils.saySimpleMessage(context, Text.translatable("nokill.command.pvp.already_disabled"));
-            }
-
-            NoKillAbilities.Abilities.PLAYER_PVP_STATUS_ABILITY.setAbilityState(player, false);
-            return Command.SINGLE_SUCCESS;
-        }
-
-    }
+//    static class PVPOnCommand implements ICommand {
+//
+//        @Override
+//        public String commandName() {
+//            return "on";
+//        }
+//
+//        @Override
+//        public LiteralArgumentBuilder<ServerCommandSource> registerNode() {
+//            return CommandManager.literal(commandName())
+//                    .executes(this::execute);
+//        }
+//
+//        private int execute(CommandContext<ServerCommandSource> context) {
+//            ServerPlayerEntity player = context.getSource().getPlayer();
+//            boolean playerPVPStatus = NoKillAbilities.Abilities.PLAYER_PVP_STATUS_ABILITY.getAbilityState(player);
+//
+//            if (!playerPVPStatus) {
+//                SebaUtils.ChatUtils.saySimpleMessage(context, Text.translatable("nokill.command.pvp.enabled"));
+//            } else {
+//                SebaUtils.ChatUtils.saySimpleMessage(context, Text.translatable("nokill.command.pvp.already_enabled"));
+//            }
+//
+//            NoKillAbilities.Abilities.PLAYER_PVP_STATUS_ABILITY.setAbilityState(player, true);
+//            return Command.SINGLE_SUCCESS;
+//        }
+//
+//    }
+//
+//    static class PVPOffCommand implements ICommand {
+//
+//        @Override
+//        public String commandName() {
+//            return "off";
+//        }
+//
+//        @Override
+//        public LiteralArgumentBuilder<ServerCommandSource> registerNode() {
+//            return CommandManager.literal(commandName())
+//                    .executes(this::execute);
+//        }
+//
+//        private int execute(CommandContext<ServerCommandSource> context) {
+//            ServerPlayerEntity player = context.getSource().getPlayer();
+//            boolean playerPVPStatus = NoKillAbilities.Abilities.PLAYER_PVP_STATUS_ABILITY.getAbilityState(player);
+//
+//            if (playerPVPStatus) {
+//                SebaUtils.ChatUtils.saySimpleMessage(context, Text.translatable("nokill.command.pvp.disabled"));
+//            } else {
+//                SebaUtils.ChatUtils.saySimpleMessage(context, Text.translatable("nokill.command.pvp.already_disabled"));
+//            }
+//
+//            NoKillAbilities.Abilities.PLAYER_PVP_STATUS_ABILITY.setAbilityState(player, false);
+//            return Command.SINGLE_SUCCESS;
+//        }
+//
+//    }
 
 }

--- a/src/main/java/dev/sebastianb/nokill/command/challenge/ChallengeCommand.java
+++ b/src/main/java/dev/sebastianb/nokill/command/challenge/ChallengeCommand.java
@@ -98,11 +98,12 @@ public class ChallengeCommand implements ICommand {
         var opponentName = pair.opponent().getName();
 
         ChallengeInviteTimer.playerInvites.remove(pair);
+        pair.increaseChallengeAttempts(); // add to both of their challenges attempted counts
         // sends message to each player letting them know request has been accepted.
         pair.challenger().sendMessage(Text.translatable("nokill.command.pvp.challenge.accepted_sent", opponentName));
         pair.opponent().sendMessage(Text.translatable("nokill.command.pvp.challenge.accepted_received", challengerName));
 
-        challenges.add(pair);
+        challenges.add(pair); // begin challenge
         // broadcast message to each player saying a duel has started
         // TODO: configurable if this should announce to only the players or everyone
         var server = context.getSource().getServer();

--- a/src/main/java/dev/sebastianb/nokill/command/challenge/PlayerPair.java
+++ b/src/main/java/dev/sebastianb/nokill/command/challenge/PlayerPair.java
@@ -1,10 +1,17 @@
 package dev.sebastianb.nokill.command.challenge;
 
+import dev.sebastianb.nokill.state.ChallengesState;
 import net.minecraft.server.network.ServerPlayerEntity;
 
 public record PlayerPair(ServerPlayerEntity challenger, ServerPlayerEntity opponent) {
     public boolean contains(ServerPlayerEntity player) {
         return (player == challenger || player == opponent);
+    }
+
+    /** Increase the challenges attempted value of both players in pair by 1 */
+    public void increaseChallengeAttempts() {
+        ChallengesState.doWithPlayerState(challenger, playerState -> playerState.challengeAttempts++);
+        ChallengesState.doWithPlayerState(opponent, playerState -> playerState.challengeAttempts++);
     }
 
     // For all intents and purposes, a pair should be equal if it contains both of the same players

--- a/src/main/java/dev/sebastianb/nokill/command/challenge/pairstructs/PlayerInviteList.java
+++ b/src/main/java/dev/sebastianb/nokill/command/challenge/pairstructs/PlayerInviteList.java
@@ -7,11 +7,12 @@ import java.util.ArrayList;
 import java.util.Optional;
 
 public class PlayerInviteList extends ArrayList<InvitePair> {
+    /** Removes an InvitePair that contains the given pair */
     public void remove(PlayerPair pair) throws IndexOutOfBoundsException {
         for (int i = 0; i < this.size(); i++) {
             if (this.get(i).pair.equals(pair)) {
                 this.remove(i);
-                return;
+                break;
             }
         }
     }

--- a/src/main/java/dev/sebastianb/nokill/command/challenge/pairstructs/PlayerPairList.java
+++ b/src/main/java/dev/sebastianb/nokill/command/challenge/pairstructs/PlayerPairList.java
@@ -7,20 +7,11 @@ import java.util.ArrayList;
 import java.util.Optional;
 
 public class PlayerPairList extends ArrayList<PlayerPair> {
-    /**
-     * Will get the pair this UUID is contained in, optional will be empty if such pair doesn't exist
-     */
+    /** @return an Optional of a PlayerPair containing the given player */
     public Optional<PlayerPair> find(ServerPlayerEntity player) {
         for (var pair : this)
             if (pair.contains(player)) return Optional.of(pair);
 
         return Optional.empty();
-    }
-
-    /**
-     * Returns true if the given UUID is in any challenge currently (in playerPairs)
-     */
-    public boolean contains(ServerPlayerEntity player) {
-        return find(player).isPresent();
     }
 }

--- a/src/main/java/dev/sebastianb/nokill/command/challenge/pairstructs/PlayerPairList.java
+++ b/src/main/java/dev/sebastianb/nokill/command/challenge/pairstructs/PlayerPairList.java
@@ -14,4 +14,11 @@ public class PlayerPairList extends ArrayList<PlayerPair> {
 
         return Optional.empty();
     }
+
+    /**
+     * Returns true if the given UUID is in any challenge currently (in playerPairs)
+     */
+    public boolean contains(ServerPlayerEntity player) {
+        return find(player).isPresent();
+    }
 }

--- a/src/main/java/dev/sebastianb/nokill/state/ChallengesState.java
+++ b/src/main/java/dev/sebastianb/nokill/state/ChallengesState.java
@@ -1,0 +1,90 @@
+package dev.sebastianb.nokill.state;
+
+import dev.sebastianb.nokill.NoKill;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.PersistentState;
+import net.minecraft.world.World;
+
+import java.util.HashMap;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.logging.Level;
+
+public class ChallengesState extends PersistentState {
+    private static final String KEY_PLAYERS_COMPOUND = "nokill.playerStates";
+    private static final String KEY_CHALLENGE_ATTEMPTS_INT = "challengeAttempts";
+    private static final String KEY_CHALLENGE_WINS_INT = "challengeWins";
+
+    public final HashMap<UUID, PlayerState> playerStateMap = new HashMap<>();
+
+    public static ChallengesState getServerState(MinecraftServer server) {
+        var overworld = server.getWorld(World.OVERWORLD);
+        if (overworld == null) throw new RuntimeException("The overworld does not exist!?");
+
+        var stateManager = overworld.getPersistentStateManager();
+
+        return stateManager.getOrCreate(ChallengesState::createFromNBT, ChallengesState::new, NoKill.MOD_ID);
+    }
+
+//    public static PlayerState getPlayerState(LivingEntity player) {
+//        var server = player.world.getServer();
+//        if (server == null) throw new RuntimeException("Player " + player + " has no server!?");
+//
+//        var state = getServerState(server);
+//
+//        return state.playerStateMap.computeIfAbsent(player.getUuid(), uuid -> new PlayerState());
+//    }
+
+    /**
+     * Will run the given consumer on the PlayerState for the given player, and then mark the
+     * ChallengesState instance as dirty so the caller does not need to worry about it.
+     */
+    public static void doWithPlayerState(LivingEntity player, Consumer<PlayerState> func) {
+        var server = player.world.getServer();
+        if (server == null) throw new RuntimeException("Player " + player + " has no server!?");
+        var serverState = getServerState(server);
+
+        var playerState = serverState.playerStateMap.computeIfAbsent(player.getUuid(), uuid -> new PlayerState());
+        func.accept(playerState);
+
+        serverState.markDirty();
+    }
+
+    public static ChallengesState createFromNBT(NbtCompound nbt) {
+        var state = new ChallengesState();
+
+        var allPlayersComp = nbt.getCompound(KEY_PLAYERS_COMPOUND);
+        for (var key : allPlayersComp.getKeys()) {
+            var playerCompound = allPlayersComp.getCompound(key);
+            var playerState = new PlayerState();
+
+            playerState.challengeAttempts = playerCompound.getInt(KEY_CHALLENGE_ATTEMPTS_INT);
+            playerState.challengeWins = playerCompound.getInt(KEY_CHALLENGE_WINS_INT);
+
+            var uuid = UUID.fromString(key);
+            state.playerStateMap.put(uuid, playerState);
+        }
+
+        return state;
+    }
+
+    @Override
+    public NbtCompound writeNbt(NbtCompound nbt) {
+        var allPlayersComp = new NbtCompound();
+        for (var id : playerStateMap.keySet()) {
+            var playerData = playerStateMap.get(id);
+            var playerCompound = new NbtCompound();
+
+            playerCompound.putInt(KEY_CHALLENGE_ATTEMPTS_INT, playerData.challengeAttempts);
+            playerCompound.putInt(KEY_CHALLENGE_WINS_INT, playerData.challengeWins);
+
+            allPlayersComp.put(id.toString(), playerCompound);
+        }
+        nbt.put(KEY_PLAYERS_COMPOUND, allPlayersComp);
+
+        return nbt;
+    }
+}

--- a/src/main/java/dev/sebastianb/nokill/state/ChallengesState.java
+++ b/src/main/java/dev/sebastianb/nokill/state/ChallengesState.java
@@ -10,8 +10,6 @@ import net.minecraft.world.World;
 import java.util.HashMap;
 import java.util.UUID;
 import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.logging.Level;
 
 public class ChallengesState extends PersistentState {
     private static final String KEY_PLAYERS_COMPOUND = "nokill.playerStates";

--- a/src/main/java/dev/sebastianb/nokill/state/PlayerState.java
+++ b/src/main/java/dev/sebastianb/nokill/state/PlayerState.java
@@ -1,0 +1,6 @@
+package dev.sebastianb.nokill.state;
+
+public class PlayerState {
+    public int challengeAttempts = 0;
+    public int challengeWins = 0;
+}

--- a/src/main/resources/data/nokill/lang/es_es.json
+++ b/src/main/resources/data/nokill/lang/es_es.json
@@ -9,7 +9,7 @@
   "nokill.command.pvp.challenge.invite_player_sent": "§l§cLe mandaste a %s §l§ca una invitacion.",
   "nokill.command.pvp.challenge.invite_player_received": "%s §l§cte ha invitado a una pelea. %s",
   "nokill.command.pvp.challenge.invite_player_received.click_here": "§l§c§n¡Apreta aqui para acceptar!",
-  "nokill.command.pvp.challenge.invite_response_info": "§l§cO, puedes responder con /pvp challenge *el nombre de ellos*",
+  "nokill.command.pvp.challenge.invite_response_info": "§l§cO, puedes responder con /pvp challenge %s",
   "nokill.command.pvp.challenge.accepted_sent": "%s §l§cha acceptado tu invitacion.",
   "nokill.command.pvp.challenge.accepted_received": "§l§cHas acceptado el desafio de %s§l§c.",
   "nokill.command.pvp.challenge.inform_of_invite_time": "§l§2Tienes %d §l§2segundos para acceptar.",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -3,10 +3,10 @@
   "id": "nokill",
   "version": "${version}",
   "name": "nokill",
-  "description": "",
+  "description": "Enables starting challenges amongst players through /pvp command",
   "authors": [],
   "contact": {
-    "repo": ""
+    "repo": "https://github.com/SebaSphere/nokill"
   },
   "license": "MIT",
   "icon": "assets/nokill/icon.png",


### PR DESCRIPTION
I decided to remove the pvp on/off commands to make the challenge tracking make sense (as it holds more value now), and this way people can truly only hurt each other if currently in a challenge.